### PR TITLE
修复文章内同博客文章跳转与文章内toc滑动时导致全屏与非全屏切换

### DIFF
--- a/source/js/script.js
+++ b/source/js/script.js
@@ -56,7 +56,12 @@ $(document).on({
 
         /*移动端打开文章后，自动隐藏文章列表*/
         if ($(window).width() <= 1024) {
-            $fullBtn.trigger("click");
+            if ($fullBtn.children().hasClass("max")) {
+                $fullBtn.trigger("click");
+            } else if ($(".nav").hasClass("mobile")) {
+                $(".nav").removeClass("mobile");
+                $fullBtn.children().removeClass("mobile");
+            }
         }
     },
     'click': function (e) {
@@ -379,11 +384,6 @@ function inputChange() {
 /*隐藏/显示 文章列表*/
 $(".full-toc .full,.semicircle").click(function (e) {
     isFullScreen = !isFullScreen
-    if ($(window).width() <= 1024 && $(".nav").hasClass("mobile")) {
-        $(".nav").removeClass("mobile");
-        $fullBtn.children().removeClass("mobile");
-        return;
-    }
     if ($fullBtn.children().hasClass("min")) {
         $fullBtn.children().removeClass("min").addClass("max");
         $(".nav, .hide-list").addClass("fullscreen");
@@ -649,14 +649,6 @@ function bind() {
         container.animate({scrollTop: container.scrollTop > targetOffsetTop ? (targetOffsetTop + 20) : (targetOffsetTop - 20)}, 500, 'swing', function () {
             clickScrollTo = false
         });
-        if ($(window).width() <= 1024) {
-
-        }
-        if ($(window).width() <= 1024) {
-            $fullBtn.trigger("click");
-        } else if ($(".full-toc .full span").hasClass("max")) {
-            $fullBtn.trigger("click");
-        }
         return false;
     });
     if ($("#comments").hasClass("disqus")) {


### PR DESCRIPTION
# 问题描述
- 文章内有博客中的其他文章地址时, 在手机端点击跳转会发生全屏切换, 导致看到的内容是文章列表, 而不是文章内容,这时需要手动再点击全屏切换才能看到内容.
- 文章内添加了toc目录, 在点击跳转时, 会发生全屏切换(如果是全屏,会切换到非全屏),特别是在手机端,会导致从内容]界面切到了文章列表页面,仍需要手动再次点击全屏切换操作.