### PR TITLE
Fix: 修复 utterance 第一次加载一定失败

### DIFF
--- a/layout/_partial/comments/utteranc.ejs
+++ b/layout/_partial/comments/utteranc.ejs
@@ -1,10 +1,16 @@
 <div id="comments">
-    <script src="https://utteranc.es/client.js"
-            repo="<%=theme.utteranc.repo%>"
-            issue-term="<%=theme.utteranc.issue_term%>"
-            theme="<%=theme.utteranc.theme%>"
-            label="<%=theme.utteranc.label%>"
-            crossorigin="anonymous"
-            async>
-    </script>
+<script>
+{
+    const comments = document.getElementById('comments');
+    const script = document.createElement('script');
+    script.src = 'https://utteranc.es/client.js';
+    script.setAttribute('repo', "<%=theme.utteranc.repo%>");
+    script.setAttribute('issue-term', "<%=theme.utteranc.issue_term%>");
+    script.setAttribute('theme', "<%=theme.utteranc.theme%>");
+    script.setAttribute('label', "<%=theme.utteranc.label%>");
+    script.setAttribute('crossorigin', 'anonymous');
+    script.setAttribute('async', '');
+    comments.appendChild(script)
+}
+</script>
 </div>


### PR DESCRIPTION
utterances需要script标签上的属性如issue-term, theme等才能把评论组件加载出来。但是由于主题中使用了jquery-pjax，jquery插入script标签时会将这些属性去除掉，导致utterances使用不正常，要第二次加载才能显示出评论组件，如这个issue: https://github.com/yelog/hexo-theme-3-hexo/issues/110

这个PR通过 https://github.com/utterance/utterances/issues/82 中提供的方法，绕过这个问题。