### PR TITLE
fix: 修复环境为chromium内核的浏览器时，点击分类，分类会闪烁的问题

### DIFF
--- a/source/css/_partial/nav-left.styl
+++ b/source/css/_partial/nav-left.styl
@@ -72,10 +72,10 @@
         overflow hidden
         &:hover
           color #f7f7f7
-          box-shadow inset 6px 0 0 #fff
+          box-shadow inset 6px 0 0.09px #fff
         &.active
           color #020202
-          box-shadow inset 165px 0 0 #fff
+          box-shadow inset 165px 0 0.09px #fff
         &>.fold
           left: 4px
           font-size 0.7em


### PR DESCRIPTION
经测试 chrome、edge有此问题，Firefox、IE11则无
修复方法参考信息：
https://stackoverflow.com/questions/46960449/how-to-avoid-flickering-on-box-shadow-transition
https://www.runoob.com/cssref/css3-pr-box-shadow.html