### PR TITLE
目录样式优化

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -61,6 +61,10 @@ category:
 # 快捷键
 shortcutKey: true
 
+#WW 是否启用目录展开/折叠功能
+toc_collapse:
+  type: 0 # 0：关闭该功能 1：启用该功能，并默认全部折叠。2：启用该功能，并默认全部展开
+
 # 左下角自定义菜单
 menu:
   about:  # '关于' 按钮

--- a/layout/_partial/nav-right.ejs
+++ b/layout/_partial/nav-right.ejs
@@ -13,6 +13,7 @@
             <i class="iconfont icon-tag" data-title="标签"></i>
         </div>
         <div id="outline-panel" style="display: none">
+            <i class="iconfont icon-file-tree" data-title="展开/收缩全部目录"></i>
             <div class="right-title">大纲</div>
             <i class="iconfont icon-list" data-title="切换到文章列表"></i>
         </div>
@@ -39,6 +40,6 @@
 
         </div>
     </nav>
-    <div id="outline-list">
+    <div id="outline-list" toc-collapse-type="<%=theme.toc_collapse.type %>">
     </div>
 </div>

--- a/source/css/_partial/nav-right.styl
+++ b/source/css/_partial/nav-right.styl
@@ -39,7 +39,7 @@ right-top-height = 45px
           &.icon-search
             left 15px
             &.active
-              color #007fff
+              color #309e85 //WW #007fff
           &.icon-file-tree
             right 15px
             font-size 18px
@@ -175,8 +175,8 @@ right-top-height = 45px
         background #309E85
       .toc
         list-style-type: none
-        font-size: 1rem
-        line-height: 1.3
+        font-size: 0.8rem   //WW  字体大小
+        line-height: 1  //WW  行高
         padding 0
         color rgb(51, 51, 51)
         font-weight 400
@@ -203,10 +203,12 @@ right-top-height = 45px
               height: 6px
         ol
           list-style-type: none
+          padding-left: 10px //WW 左边距
         a
           display: block
           position: relative
           padding: 4px 0 4px 12px
+          padding-left: 0px !important //WW 左边距
           white-space: nowrap
           overflow: hidden
           text-overflow: ellipsis
@@ -215,7 +217,7 @@ right-top-height = 45px
             background-color: #ebedef
           &.active
             background-color: #ebedef
-            color #007fff
+            color #309e85 //WW #007fff
           &:before
             content: ""
             position: absolute
@@ -224,11 +226,13 @@ right-top-height = 45px
             margin-top: -2px
             width: 4px
             height: 4px
-            background-color: currentColor
+            //WW background-color: currentColor
             border-radius: 50%
-        // 折叠目录按钮样式
+        //WW
         .toc-collapse-btn
-          color: #007fff 
+          color: #309e85 //WW #007fff
+          margin-right: 4px
+          float: left
     nav, #local-search-result
       clear both
       width 100%

--- a/source/css/_partial/nav-right.styl
+++ b/source/css/_partial/nav-right.styl
@@ -23,7 +23,7 @@ right-top-height = 45px
       top: 0
       width: 100%
       font-size 15px
-      #default-panel, #outline-panel
+      #default-panel
         text-align center
         height right-top-height
         .right-title
@@ -42,6 +42,22 @@ right-top-height = 45px
               color #007fff
           &.icon-file-tree
             right 15px
+            font-size 18px
+      #outline-panel
+        text-align center
+        height right-top-height
+        .right-title
+          height right-top-height
+          line-height right-top-height
+          font-size 18px
+        .iconfont
+          position absolute
+          top 50%
+          transform: translate(0, -50%)
+          cursor pointer
+          font-size 16px
+          &.icon-file-tree
+            left 15px
             font-size 18px
           &.icon-list
             right 15px
@@ -210,6 +226,9 @@ right-top-height = 45px
             height: 4px
             background-color: currentColor
             border-radius: 50%
+        // 折叠目录按钮样式
+        .toc-collapse-btn
+          color: #007fff 
     nav, #local-search-result
       clear both
       width 100%


### PR DESCRIPTION
目录样式优化：
1.减小目录字体。
2.左侧缩进调整，行间距调整。
3.颜色调整。
样式根据个人审美及需求调整优化，仅供参考，如采纳，合并source/css/_partial/nav-right.styl一个文件即可，其他文件为“目录折叠功能”代码。