### PR TITLE
正文样式优化

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -61,6 +61,10 @@ category:
 # 快捷键
 shortcutKey: true
 
+#WW 是否启用目录展开/折叠功能
+toc_collapse:
+  type: 0 # 0：关闭该功能 1：启用该功能，并默认全部折叠。2：启用该功能，并默认全部展开
+
 # 左下角自定义菜单
 menu:
   about:  # '关于' 按钮

--- a/layout/_partial/nav-right.ejs
+++ b/layout/_partial/nav-right.ejs
@@ -13,6 +13,7 @@
             <i class="iconfont icon-tag" data-title="标签"></i>
         </div>
         <div id="outline-panel" style="display: none">
+            <i class="iconfont icon-file-tree" data-title="展开/收缩全部目录"></i>
             <div class="right-title">大纲</div>
             <i class="iconfont icon-list" data-title="切换到文章列表"></i>
         </div>
@@ -39,6 +40,6 @@
 
         </div>
     </nav>
-    <div id="outline-list">
+    <div id="outline-list" toc-collapse-type="<%=theme.toc_collapse.type %>">
     </div>
 </div>

--- a/source/css/_partial/nav-right.styl
+++ b/source/css/_partial/nav-right.styl
@@ -23,7 +23,7 @@ right-top-height = 45px
       top: 0
       width: 100%
       font-size 15px
-      #default-panel, #outline-panel
+      #default-panel
         text-align center
         height right-top-height
         .right-title
@@ -42,6 +42,22 @@ right-top-height = 45px
               color #007fff
           &.icon-file-tree
             right 15px
+            font-size 18px
+      #outline-panel
+        text-align center
+        height right-top-height
+        .right-title
+          height right-top-height
+          line-height right-top-height
+          font-size 18px
+        .iconfont
+          position absolute
+          top 50%
+          transform: translate(0, -50%)
+          cursor pointer
+          font-size 16px
+          &.icon-file-tree
+            left 15px
             font-size 18px
           &.icon-list
             right 15px
@@ -210,6 +226,9 @@ right-top-height = 45px
             height: 4px
             background-color: currentColor
             border-radius: 50%
+        // 折叠目录按钮样式
+        .toc-collapse-btn
+          color: #007fff 
     nav, #local-search-result
       clear both
       width 100%

--- a/source/css/_partial/post.styl
+++ b/source/css/_partial/post.styl
@@ -1,4 +1,27 @@
 #post
+  //WW 定制
+  em // 斜体
+    color: #EE7700
+    font-style: normal
+  strong // 黑体
+    color: #F538A0
+  :not(pre) > code // 行内代码块
+    background-color: #ebedef !important
+    color: #00AA55 !important
+  p // 段前段后间距
+    margin-top: 0 !important
+    margin-bottom: 1.5rem !important
+    line-height: 1.5rem !important
+  ul // 无序列表间距
+    margin-top: 0rem !important
+    margin-bottom: 1.5rem !important
+  ol // 有序列表间距
+    margin-top: 0rem !important
+    margin-bottom: 1.5rem !important
+  li // 子列表
+    margin-bottom: 0rem !important
+  
+
   height 100%
   font-weight: 400;
   font-size: 16px;
@@ -15,7 +38,7 @@
     background #33caa6
     text-shadow none
   .pjax
-    max-width 900px
+    max-width 1200px  //WW 扩大文章宽度
     min-height calc(100vh - 143px)
     margin 0 auto
     overflow-y auto


### PR DESCRIPTION
参照Tyora样式调整优化了博客文章样式，提高可读性：
1.行间距调整，段前段后间距调整。
2.样色调整：黑体显示紫红色，斜体显示黄色，行内代码块显示绿色。
3.加宽宽度，减小字体。
样式根据个人审美及需求调整优化，仅供参考，如采纳，合并source/css/_partial/post.styl一个文件即可，其他文件为“目录折叠功能”代码。