### PR TITLE
add support for giscus, another comment component

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -229,7 +229,7 @@ friends:
 ##########评论设置#############
 comment:
   on: false
-  type: gitalk  # 评论系统：gitalk、disqus、gitment、utteranc、livere,注意：使用时，在下方对应位置进行配置
+  type: gitalk  # 评论系统：gitalk、disqus、gitment、utteranc、livere、giscus,注意：使用时，在下方对应位置进行配置
   comment_count: true  # 文章标题下方显示评论数 目前仅支持 gitalk 和 disqus
   ## 使用说明 https://yelog.org//2020/05/23/3-hexo-comment/
 # 各评论系统配置 ↓↓
@@ -282,6 +282,21 @@ utteranc:
   theme: github-light     # 主题，可选主题请查看官方文档 https://utteranc.es/#heading-theme
 # 官方文档 https://utteranc.es/
 # 使用说明 https://yelog.org//2020/05/23/3-hexo-comment/
+
+giscus:
+  repo: xxx/xxx             # 用于承载评论的仓库
+  repoId: xxx               # 仓库ID,从giscus网站获取
+  category: General         # Discussion主题分类
+  categoryId: x             # 分类ID,从giscus网站获取
+  mapping: pathname         # Github讨论与博客文章之间的映射关系, pathname url title og:title
+  strict: 0                 # 是否使用严格的标题匹配, 0 1
+  reactionsEnabled: 1       # 是否使用Github讨论的Reactions, 0 1
+  emitMetadata: 1           # 是否输出Github讨论的元数据, 0 1
+  inputPosition: top        # 输入框位置, top bottom
+  theme: light              # 主题, 支持的主题请查看giscus网站
+  lang: zh-CN               # 主题语言,支持的语言请查看giscus网站
+  loading: lazy             # 是否启用懒加载
+  # 官方文档: https://giscus.app/
 
 ##############################
 

--- a/layout/_partial/comments/giscus.ejs
+++ b/layout/_partial/comments/giscus.ejs
@@ -1,0 +1,24 @@
+<div id="comments">
+    <script>
+        {
+            const comments = document.getElementById("comments");
+            const script = document.createElement("script");
+            script.src = "https://giscus.app/client.js";
+            script.setAttribute('data-repo', "<%=theme.giscus.repo%>");
+            script.setAttribute('data-repo-id', "<%=theme.giscus.repoId%>");
+            script.setAttribute('data-category', "<%=theme.giscus.category%>");
+            script.setAttribute('data-category-id', "<%=theme.giscus.categoryId%>");
+            script.setAttribute('data-mapping', "<%=theme.giscus.mapping%>");
+            script.setAttribute('data-strict', "<%=theme.giscus.strict%>");
+            script.setAttribute('data-reactions-enabled', "<%=theme.giscus.reactionsEnabled%>");
+            script.setAttribute('data-emit-metadata', "<%=theme.giscus.emitMetadata%>");
+            script.setAttribute('data-input-position', "<%=theme.giscus.inputPosition%>");
+            script.setAttribute('data-theme', "<%=theme.giscus.theme%>");
+            script.setAttribute('data-lang', "<%=theme.giscus.lang%>");
+            script.setAttribute('data-loading', "<%=theme.giscus.loading%>");
+            script.setAttribute('crossorigin', "anonymous");
+            script.setAttribute('async', "");
+            comments.appendChild(script);
+        }
+    </script>
+</div>


### PR DESCRIPTION
This PR is for adding support for giscus which is based on utteranc.

In components which this repo supported, I prefer gitalk and utteranc. But they still not good enough:

1. gitalk need load a `.js` file which have a big size. Hexo blog always deploy on github pages, this maybe take much time on load `gitalk.js`.
2. utteranc is too simple, only can add comments.

I think giscus is better than above 2 components. 

1. giscus only have a small size dependencies
2. giscus is depend on github dicussions, it can achieve more features
3. now giscus and github discussions both active, there're will be more new features

More, giscus also can count comments. But now I haven't add it to this PR. It's valuable if we can explore on it.

Finally, this is simple screenshot for giscus in 3-hexo:

![image](https://github.com/yelog/hexo-theme-3-hexo/assets/43563921/3855c18b-22e2-41a8-8ce5-c94a8cf902e0)
